### PR TITLE
Add WinForms GLTF→PSG converter using donor skeleton data

### DIFF
--- a/GltfToPsgConverter/GltfToPsgConverter.csproj
+++ b/GltfToPsgConverter/GltfToPsgConverter.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\sK8\sK8.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="SharpGLTF.Core" Version="1.0.5" />
+  </ItemGroup>
+</Project>

--- a/GltfToPsgConverter/Program.cs
+++ b/GltfToPsgConverter/Program.cs
@@ -1,0 +1,584 @@
+using SharpGLTF.Schema2;
+using sK8.Renderware.Psg;
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace GltfToPsgConverter
+{
+    internal static class Program
+    {
+        [STAThread]
+        private static void Main()
+        {
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+            Application.Run(new MainForm());
+        }
+    }
+
+    public sealed class MainForm : Form
+    {
+        private readonly TextBox _txtDonor;
+        private readonly TextBox _txtGltf;
+        private readonly TextBox _txtOutput;
+        private readonly TextBox _txtLog;
+        private readonly Button _btnConvert;
+
+        public MainForm()
+        {
+            Text = "GLTF → PSG Converter";
+            StartPosition = FormStartPosition.CenterScreen;
+            MinimumSize = new System.Drawing.Size(900, 600);
+
+            var layout = new TableLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                ColumnCount = 4,
+                RowCount = 6,
+                Padding = new Padding(10)
+            };
+            layout.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 120));
+            layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100));
+            layout.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 120));
+            layout.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 120));
+
+            layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            layout.RowStyles.Add(new RowStyle(SizeType.Percent, 100));
+
+            layout.Controls.Add(new Label { Text = "Donor PSG:", AutoSize = true, Anchor = AnchorStyles.Left }, 0, 0);
+            _txtDonor = new TextBox { Anchor = AnchorStyles.Left | AnchorStyles.Right };
+            layout.Controls.Add(_txtDonor, 1, 0);
+            layout.SetColumnSpan(_txtDonor, 2);
+            var btnDonor = new Button { Text = "Browse...", Anchor = AnchorStyles.Left };
+            btnDonor.Click += (s, e) => BrowseFile(_txtDonor, "Select donor PSG", "PSG files (*.psg)|*.psg|All files (*.*)|*.*");
+            layout.Controls.Add(btnDonor, 3, 0);
+
+            layout.Controls.Add(new Label { Text = "GLTF/GLB:", AutoSize = true, Anchor = AnchorStyles.Left }, 0, 1);
+            _txtGltf = new TextBox { Anchor = AnchorStyles.Left | AnchorStyles.Right };
+            layout.Controls.Add(_txtGltf, 1, 1);
+            layout.SetColumnSpan(_txtGltf, 2);
+            var btnGltf = new Button { Text = "Browse...", Anchor = AnchorStyles.Left };
+            btnGltf.Click += (s, e) => BrowseFile(_txtGltf, "Select GLTF", "GLTF/GLB files (*.gltf;*.glb)|*.gltf;*.glb|All files (*.*)|*.*");
+            layout.Controls.Add(btnGltf, 3, 1);
+
+            layout.Controls.Add(new Label { Text = "Output PSG:", AutoSize = true, Anchor = AnchorStyles.Left }, 0, 2);
+            _txtOutput = new TextBox { Anchor = AnchorStyles.Left | AnchorStyles.Right };
+            layout.Controls.Add(_txtOutput, 1, 2);
+            layout.SetColumnSpan(_txtOutput, 2);
+            var btnOutput = new Button { Text = "Browse...", Anchor = AnchorStyles.Left };
+            btnOutput.Click += (s, e) => BrowseSaveFile(_txtOutput, "Save converted PSG", "PSG files (*.psg)|*.psg|All files (*.*)|*.*");
+            layout.Controls.Add(btnOutput, 3, 2);
+
+            _btnConvert = new Button { Text = "Convert", Anchor = AnchorStyles.Left, Width = 120 };
+            _btnConvert.Click += async (s, e) => await ConvertAsync();
+            layout.Controls.Add(_btnConvert, 0, 3);
+
+            var lblHint = new Label
+            {
+                Text = "The donor PSG provides bone and vertex layout information. The GLTF must contain a mesh bound to a compatible skin.",
+                AutoSize = true,
+                MaximumSize = new System.Drawing.Size(600, 0),
+                Anchor = AnchorStyles.Left
+            };
+            layout.Controls.Add(lblHint, 1, 3);
+            layout.SetColumnSpan(lblHint, 3);
+
+            layout.Controls.Add(new Label { Text = "Log:", AutoSize = true, Anchor = AnchorStyles.Left }, 0, 4);
+            _txtLog = new TextBox
+            {
+                Multiline = true,
+                ScrollBars = ScrollBars.Both,
+                WordWrap = false,
+                Font = new System.Drawing.Font("Consolas", 9f),
+                Dock = DockStyle.Fill
+            };
+            layout.Controls.Add(_txtLog, 0, 5);
+            layout.SetColumnSpan(_txtLog, 4);
+
+            Controls.Add(layout);
+        }
+
+        private void BrowseFile(TextBox target, string title, string filter)
+        {
+            using var dialog = new OpenFileDialog { Title = title, Filter = filter };
+            if (dialog.ShowDialog(this) == DialogResult.OK)
+            {
+                target.Text = dialog.FileName;
+                if (target == _txtDonor && string.IsNullOrWhiteSpace(_txtOutput.Text))
+                {
+                    _txtOutput.Text = Path.Combine(Path.GetDirectoryName(dialog.FileName) ?? string.Empty, Path.GetFileNameWithoutExtension(dialog.FileName) + "_converted.psg");
+                }
+            }
+        }
+
+        private void BrowseSaveFile(TextBox target, string title, string filter)
+        {
+            using var dialog = new SaveFileDialog { Title = title, Filter = filter };
+            if (!string.IsNullOrWhiteSpace(target.Text))
+            {
+                dialog.FileName = target.Text;
+            }
+            if (dialog.ShowDialog(this) == DialogResult.OK)
+            {
+                target.Text = dialog.FileName;
+            }
+        }
+
+        private async Task ConvertAsync()
+        {
+            var donorPath = _txtDonor.Text.Trim();
+            var gltfPath = _txtGltf.Text.Trim();
+            var outputPath = _txtOutput.Text.Trim();
+
+            if (!File.Exists(donorPath))
+            {
+                MessageBox.Show(this, "Select a donor PSG first.", "Missing PSG", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+            if (!File.Exists(gltfPath))
+            {
+                MessageBox.Show(this, "Select a GLTF/GLB file.", "Missing GLTF", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+            if (string.IsNullOrWhiteSpace(outputPath))
+            {
+                MessageBox.Show(this, "Choose an output path for the converted PSG.", "Missing output", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
+            try
+            {
+                _btnConvert.Enabled = false;
+                UseWaitCursor = true;
+                _txtLog.Clear();
+                Log($"Donor PSG: {donorPath}");
+                Log($"GLTF: {gltfPath}");
+                Log($"Output: {outputPath}");
+
+                await Task.Run(() => ConvertInternal(donorPath, gltfPath, outputPath));
+
+                Log("Conversion complete.");
+                MessageBox.Show(this, "Conversion complete.", "Done", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+            catch (Exception ex)
+            {
+                Log($"[ERROR] {ex}");
+                MessageBox.Show(this, $"Conversion failed:\n{ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+            finally
+            {
+                UseWaitCursor = false;
+                _btnConvert.Enabled = true;
+            }
+        }
+
+        private void ConvertInternal(string donorPath, string gltfPath, string outputPath)
+        {
+            Log("Loading donor PSG...");
+            var donorBytes = File.ReadAllBytes(donorPath);
+            var donorMesh = PsgDonorMesh.Load(donorBytes, Log);
+
+            Log("Loading GLTF...");
+            var model = ModelRoot.Load(gltfPath);
+            var meshData = LoadGltfMesh(model);
+
+            if (meshData.Positions.Length != donorMesh.VertexCount)
+            {
+                throw new InvalidOperationException($"Vertex count mismatch. Donor PSG has {donorMesh.VertexCount} verts, GLTF has {meshData.Positions.Length} verts.");
+            }
+
+            var jointPaletteMap = BuildJointPaletteMap(donorMesh, meshData.Skin);
+            if (jointPaletteMap.Count == 0)
+            {
+                throw new InvalidOperationException("No overlapping bones were found between the donor PSG palette and the GLTF skin.");
+            }
+
+            var outputBytes = (byte[])donorMesh.FileBytes.Clone();
+            var vertexData = new Span<byte>(outputBytes, donorMesh.VertexBufferOffset, donorMesh.VertexBufferSize);
+
+            const float zOffset = 0.8f; // Undo import offset from Blender script
+            var rotation = Matrix4x4.CreateRotationX(-MathF.PI / 2f);
+
+            var missingNormals = meshData.Normals.Length == 0;
+            var missingTangents = meshData.Tangents.Length == 0;
+            var missingUv = meshData.Tex0.Length == 0;
+
+            if (missingNormals) Log("[WARN] GLTF does not contain normals. Existing PSG normals will be preserved.");
+            if (missingTangents) Log("[WARN] GLTF does not contain tangents. Existing PSG tangents/binormals will be preserved.");
+            if (missingUv) Log("[WARN] GLTF does not contain TEXCOORD_0. Existing PSG UVs will be preserved.");
+
+            _ = donorMesh.Descriptor.IndicesElement ?? throw new InvalidOperationException("Donor PSG descriptor has no indices element in active stream.");
+            _ = donorMesh.Descriptor.WeightsElement ?? throw new InvalidOperationException("Donor PSG descriptor has no weights element in active stream.");
+
+            var missingJointNames = new HashSet<string>();
+
+            for (int i = 0; i < donorMesh.VertexCount; i++)
+            {
+                Vector3 pos = meshData.Positions[i];
+                pos.Z -= zOffset;
+                pos = Vector3.Transform(pos, rotation);
+
+                Vector3 normal = Vector3.Zero;
+                if (!missingNormals)
+                {
+                    normal = Vector3.TransformNormal(meshData.Normals[i], rotation);
+                    if (normal.LengthSquared() > 0) normal = Vector3.Normalize(normal);
+                }
+
+                Vector4 tangent = Vector4.Zero;
+                Vector3 binormal = Vector3.Zero;
+                if (!missingTangents && meshData.Tangents.Length > i && !missingNormals)
+                {
+                    tangent = meshData.Tangents[i];
+                    var tangentVec = new Vector3(tangent.X, tangent.Y, tangent.Z);
+                    tangentVec = Vector3.TransformNormal(tangentVec, rotation);
+                    if (tangentVec.LengthSquared() > 0) tangentVec = Vector3.Normalize(tangentVec);
+                    tangent = new Vector4(tangentVec, tangent.W);
+
+                    var nrm = normal.LengthSquared() > 0 ? normal : Vector3.Zero;
+                    if (nrm != Vector3.Zero && tangentVec != Vector3.Zero)
+                    {
+                        binormal = Vector3.Normalize(Vector3.Cross(nrm, tangentVec) * tangent.W);
+                    }
+                }
+
+                Vector2 uv = Vector2.Zero;
+                if (!missingUv)
+                {
+                    uv = meshData.Tex0[i];
+                }
+
+                Span<int> paletteIndices = stackalloc int[4];
+                Span<float> paletteWeights = stackalloc float[4];
+                PopulateInfluences(i, meshData, jointPaletteMap, paletteIndices, paletteWeights, missingJointNames);
+
+                WriteVertex(vertexData, donorMesh.Descriptor, donorMesh.VertexStride, i, pos, normal, tangent, binormal, uv, paletteIndices, paletteWeights);
+            }
+
+            if (missingJointNames.Count > 0)
+            {
+                foreach (var name in missingJointNames.OrderBy(n => n))
+                {
+                    Log($"[WARN] Bone '{name}' from GLTF skin is not present in donor palette; its weights were discarded.");
+                }
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath) ?? string.Empty);
+            File.WriteAllBytes(outputPath, outputBytes);
+        }
+
+        private Dictionary<int, int> BuildJointPaletteMap(PsgDonorMesh donor, Skin skin)
+        {
+            var map = new Dictionary<int, int>();
+            for (int i = 0; i < skin.Joints.Count; i++)
+            {
+                var node = skin.Joints[i];
+                string normalized = PsgDonorMesh.NormalizeBoneName(node?.Name);
+                if (string.IsNullOrEmpty(normalized))
+                {
+                    continue;
+                }
+                if (!donor.NormalizedBoneNameToIndex.TryGetValue(normalized, out int globalIndex))
+                {
+                    continue;
+                }
+                int paletteSlot = donor.GetPaletteSlotForGlobalBone(globalIndex);
+                if (paletteSlot >= 0)
+                {
+                    map[i] = paletteSlot;
+                }
+            }
+            return map;
+        }
+
+        private void PopulateInfluences(int vertexIndex, GltfMeshData meshData, Dictionary<int, int> jointPaletteMap, Span<int> indices, Span<float> weights, HashSet<string> missing)
+        {
+            indices[0] = indices[1] = indices[2] = indices[3] = 0;
+            weights[0] = weights[1] = weights[2] = weights[3] = 0;
+
+            if (meshData.Joints.Length == 0 || meshData.Weights.Length == 0)
+            {
+                weights[0] = 1f;
+                return;
+            }
+
+            var jointsVec = meshData.Joints[vertexIndex];
+            var weightsVec = meshData.Weights[vertexIndex];
+
+            Span<int> jointIndices = stackalloc int[4]
+            {
+                (int)MathF.Round(jointsVec.X),
+                (int)MathF.Round(jointsVec.Y),
+                (int)MathF.Round(jointsVec.Z),
+                (int)MathF.Round(jointsVec.W)
+            };
+
+            Span<float> weightValues = stackalloc float[4] { weightsVec.X, weightsVec.Y, weightsVec.Z, weightsVec.W };
+
+            int count = 0;
+            for (int c = 0; c < 4; c++)
+            {
+                float w = weightValues[c];
+                if (w <= 0f) continue;
+                int joint = jointIndices[c];
+                if (!jointPaletteMap.TryGetValue(joint, out int palette))
+                {
+                    string name = meshData.GetJointName(joint);
+                    if (!string.IsNullOrEmpty(name)) missing.Add(name);
+                    continue;
+                }
+                indices[count] = palette;
+                weights[count] = w;
+                count++;
+                if (count == 4) break;
+            }
+
+            if (count == 0)
+            {
+                weights[0] = 1f;
+                indices[0] = 0;
+                return;
+            }
+
+            float sum = 0f;
+            for (int i = 0; i < count; i++) sum += weights[i];
+            if (sum > 1e-6f)
+            {
+                float inv = 1f / sum;
+                for (int i = 0; i < count; i++) weights[i] *= inv;
+            }
+            else
+            {
+                weights[0] = 1f;
+                for (int i = 1; i < 4; i++) weights[i] = 0f;
+            }
+
+            for (int i = count; i < 4; i++)
+            {
+                indices[i] = indices[0];
+                weights[i] = 0f;
+            }
+        }
+
+        private void WriteVertex(Span<byte> vertexData, PsgVertexDescriptor descriptor, int stride, int vertexIndex, Vector3 position, Vector3 normal, Vector4 tangent, Vector3 binormal, Vector2 uv, Span<int> paletteIndices, Span<float> paletteWeights)
+        {
+            var vertexSpan = vertexData.Slice(vertexIndex * stride, stride);
+            Span<float> valueBuffer = stackalloc float[4];
+
+            foreach (var element in descriptor.Elements.Where(e => e.Stream == descriptor.ActiveStream))
+            {
+                int componentSize = GetComponentSize(element.ComponentType);
+                int requiredLength = componentSize * element.ComponentCount;
+                if (element.Offset + requiredLength > vertexSpan.Length)
+                {
+                    continue;
+                }
+
+                var destination = vertexSpan.Slice(element.Offset, requiredLength);
+                int valueCount = FillElementValues(element, position, normal, tangent, binormal, uv, paletteIndices, paletteWeights, valueBuffer);
+                if (valueCount <= 0)
+                {
+                    continue;
+                }
+
+                WriteElement(destination, element, valueBuffer[..valueCount]);
+            }
+        }
+
+        private static int FillElementValues(PsgVertexElement element, Vector3 position, Vector3 normal, Vector4 tangent, Vector3 binormal, Vector2 uv, Span<int> paletteIndices, Span<float> paletteWeights, Span<float> buffer)
+        {
+            buffer.Clear();
+            switch (element.ElementType)
+            {
+                case PsgVertexElementType.Xyz:
+                    buffer[0] = position.X;
+                    buffer[1] = position.Y;
+                    buffer[2] = position.Z;
+                    return 3;
+                case PsgVertexElementType.Normal:
+                    if (normal == Vector3.Zero) return 0;
+                    buffer[0] = normal.X;
+                    buffer[1] = normal.Y;
+                    buffer[2] = normal.Z;
+                    return 3;
+                case PsgVertexElementType.Tangent:
+                    if (tangent == Vector4.Zero) return 0;
+                    buffer[0] = tangent.X;
+                    buffer[1] = tangent.Y;
+                    buffer[2] = tangent.Z;
+                    if (element.ComponentCount >= 4)
+                    {
+                        buffer[3] = tangent.W;
+                        return 4;
+                    }
+                    return Math.Min(3, element.ComponentCount);
+                case PsgVertexElementType.Binormal:
+                    if (binormal == Vector3.Zero) return 0;
+                    buffer[0] = binormal.X;
+                    buffer[1] = binormal.Y;
+                    buffer[2] = binormal.Z;
+                    return 3;
+                case PsgVertexElementType.Tex0:
+                    buffer[0] = uv.X;
+                    buffer[1] = uv.Y;
+                    return Math.Min(2, element.ComponentCount);
+                case PsgVertexElementType.Weights:
+                    for (int i = 0; i < Math.Min(4, element.ComponentCount); i++) buffer[i] = paletteWeights[i];
+                    return Math.Min(4, element.ComponentCount);
+                case PsgVertexElementType.Indices:
+                    for (int i = 0; i < Math.Min(4, element.ComponentCount); i++) buffer[i] = paletteIndices[i];
+                    return Math.Min(4, element.ComponentCount);
+                default:
+                    return 0;
+            }
+        }
+
+        private static void WriteElement(Span<byte> destination, PsgVertexElement element, ReadOnlySpan<float> values)
+        {
+            int componentSize = GetComponentSize(element.ComponentType);
+            int count = Math.Min(values.Length, element.ComponentCount);
+            switch (element.ComponentType)
+            {
+                case PsgVertexComponentType.Float32:
+                    for (int i = 0; i < element.ComponentCount; i++)
+                    {
+                        float value = i < count ? values[i] : 0f;
+                        BinaryPrimitives.WriteSingleBigEndian(destination.Slice(i * componentSize, componentSize), value);
+                    }
+                    break;
+                case PsgVertexComponentType.Float16:
+                    for (int i = 0; i < element.ComponentCount; i++)
+                    {
+                        float value = i < count ? values[i] : 0f;
+                        Half half = (Half)value;
+                        ref ushort rawRef = ref Unsafe.As<Half, ushort>(ref half);
+                        BinaryPrimitives.WriteUInt16BigEndian(destination.Slice(i * componentSize, componentSize), rawRef);
+                    }
+                    break;
+                case PsgVertexComponentType.S1:
+                    for (int i = 0; i < element.ComponentCount; i++)
+                    {
+                        float value = i < count ? values[i] : 0f;
+                        short raw = (short)MathF.Round(Math.Clamp(value, -1f, 1f) * 32767f);
+                        BinaryPrimitives.WriteInt16BigEndian(destination.Slice(i * componentSize, componentSize), raw);
+                    }
+                    break;
+                case PsgVertexComponentType.S32K:
+                    float scale = element.ElementType == PsgVertexElementType.Xyz ? 16384f : 1f;
+                    for (int i = 0; i < element.ComponentCount; i++)
+                    {
+                        float value = i < count ? values[i] : 0f;
+                        short raw = (short)Math.Clamp(MathF.Round(value * scale), short.MinValue, short.MaxValue);
+                        BinaryPrimitives.WriteInt16BigEndian(destination.Slice(i * componentSize, componentSize), raw);
+                    }
+                    break;
+                case PsgVertexComponentType.UByteNormalized:
+                    for (int i = 0; i < element.ComponentCount; i++)
+                    {
+                        float value = i < count ? values[i] : 0f;
+                        bool normalize = element.ElementType != PsgVertexElementType.Indices;
+                        byte raw = (byte)Math.Clamp(MathF.Round(normalize ? value * 255f : value), 0f, 255f);
+                        destination[i] = raw;
+                    }
+                    break;
+                case PsgVertexComponentType.UByte:
+                    for (int i = 0; i < element.ComponentCount; i++)
+                    {
+                        float value = i < count ? values[i] : 0f;
+                        byte raw = (byte)Math.Clamp(MathF.Round(value), 0f, 255f);
+                        destination[i] = raw;
+                    }
+                    break;
+                case PsgVertexComponentType.PackedCmp:
+                    // Packed 10:10:10:2 vectors are not adjusted; retain original bytes.
+                    break;
+            }
+        }
+
+        private static int GetComponentSize(PsgVertexComponentType type)
+        {
+            return type switch
+            {
+                PsgVertexComponentType.Float32 => 4,
+                PsgVertexComponentType.Float16 => 2,
+                PsgVertexComponentType.S1 => 2,
+                PsgVertexComponentType.S32K => 2,
+                PsgVertexComponentType.UByte => 1,
+                PsgVertexComponentType.UByteNormalized => 1,
+                PsgVertexComponentType.PackedCmp => 4,
+                _ => 1
+            };
+        }
+
+        private GltfMeshData LoadGltfMesh(ModelRoot model)
+        {
+            var mesh = model.LogicalMeshes.FirstOrDefault(m => m.Primitives.Count > 0)
+                ?? throw new InvalidOperationException("GLTF file does not contain a mesh with primitives.");
+            var primitive = mesh.Primitives[0];
+
+            Vector3[] positions = primitive.GetVertexAccessor("POSITION")?.AsVector3Array()
+                ?? throw new InvalidOperationException("GLTF mesh is missing POSITION data.");
+            Vector3[] normals = primitive.GetVertexAccessor("NORMAL")?.AsVector3Array() ?? Array.Empty<Vector3>();
+            Vector4[] tangents = primitive.GetVertexAccessor("TANGENT")?.AsVector4Array() ?? Array.Empty<Vector4>();
+            Vector2[] tex0 = primitive.GetVertexAccessor("TEXCOORD_0")?.AsVector2Array() ?? Array.Empty<Vector2>();
+            Vector4[] joints = primitive.GetVertexAccessor("JOINTS_0")?.AsVector4Array() ?? Array.Empty<Vector4>();
+            Vector4[] weights = primitive.GetVertexAccessor("WEIGHTS_0")?.AsVector4Array() ?? Array.Empty<Vector4>();
+
+            var node = model.LogicalNodes.FirstOrDefault(n => n.Mesh == mesh && n.Skin != null)
+                ?? model.LogicalNodes.FirstOrDefault(n => n.Skin != null);
+            var skin = node?.Skin ?? model.LogicalSkins.FirstOrDefault()
+                ?? throw new InvalidOperationException("GLTF file does not contain a skin with joints.");
+
+            return new GltfMeshData(positions, normals, tangents, tex0, joints, weights, skin);
+        }
+
+        private void Log(string message)
+        {
+            if (InvokeRequired)
+            {
+                BeginInvoke(new Action<string>(Log), message);
+                return;
+            }
+            _txtLog.AppendText(message + Environment.NewLine);
+        }
+
+        private sealed class GltfMeshData
+        {
+            public GltfMeshData(Vector3[] positions, Vector3[] normals, Vector4[] tangents, Vector2[] tex0, Vector4[] joints, Vector4[] weights, Skin skin)
+            {
+                Positions = positions;
+                Normals = normals;
+                Tangents = tangents;
+                Tex0 = tex0;
+                Joints = joints;
+                Weights = weights;
+                Skin = skin;
+            }
+
+            public Vector3[] Positions { get; }
+            public Vector3[] Normals { get; }
+            public Vector4[] Tangents { get; }
+            public Vector2[] Tex0 { get; }
+            public Vector4[] Joints { get; }
+            public Vector4[] Weights { get; }
+            public Skin Skin { get; }
+
+            public string GetJointName(int jointIndex)
+            {
+                if (jointIndex < 0 || jointIndex >= Skin.Joints.Count) return string.Empty;
+                return Skin.Joints[jointIndex]?.Name ?? string.Empty;
+            }
+        }
+    }
+}

--- a/sK8.sln
+++ b/sK8.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "sk8 Hash Helper", "sk8 Hash
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "sK8 Unit Testing", "sK8 Unit Testing\sK8 Unit Testing.csproj", "{7BAA94A3-2306-4518-8CD5-7A83C00C19C6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GltfToPsgConverter", "GltfToPsgConverter\GltfToPsgConverter.csproj", "{74322022-E550-4044-ACFD-0C8CE5ACA695}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,12 +30,16 @@ Global
 		{B37FCC19-A425-4561-BA43-236BBAA5475C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B37FCC19-A425-4561-BA43-236BBAA5475C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B37FCC19-A425-4561-BA43-236BBAA5475C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B37FCC19-A425-4561-BA43-236BBAA5475C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7BAA94A3-2306-4518-8CD5-7A83C00C19C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7BAA94A3-2306-4518-8CD5-7A83C00C19C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7BAA94A3-2306-4518-8CD5-7A83C00C19C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7BAA94A3-2306-4518-8CD5-7A83C00C19C6}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {B37FCC19-A425-4561-BA43-236BBAA5475C}.Release|Any CPU.Build.0 = Release|Any CPU
+                {7BAA94A3-2306-4518-8CD5-7A83C00C19C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {7BAA94A3-2306-4518-8CD5-7A83C00C19C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {7BAA94A3-2306-4518-8CD5-7A83C00C19C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {7BAA94A3-2306-4518-8CD5-7A83C00C19C6}.Release|Any CPU.Build.0 = Release|Any CPU
+                {74322022-E550-4044-ACFD-0C8CE5ACA695}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {74322022-E550-4044-ACFD-0C8CE5ACA695}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {74322022-E550-4044-ACFD-0C8CE5ACA695}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {74322022-E550-4044-ACFD-0C8CE5ACA695}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/sK8/Renderware/Psg/PsgDonorMesh.cs
+++ b/sK8/Renderware/Psg/PsgDonorMesh.cs
@@ -1,0 +1,673 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace sK8.Renderware.Psg
+{
+    /// <summary>
+    /// Represents the base mesh data extracted from a donor PSG file.
+    /// </summary>
+    public sealed class PsgDonorMesh
+    {
+        private PsgDonorMesh(
+            byte[] fileBytes,
+            IReadOnlyList<string> boneNames,
+            IReadOnlyDictionary<string, int> normalizedBoneIndex,
+            IReadOnlyList<ushort> bonePalette,
+            PsgVertexDescriptor descriptor,
+            int vertexCount,
+            int vertexStride,
+            int vertexBufferOffset,
+            int vertexBufferSize)
+        {
+            FileBytes = fileBytes;
+            BoneNames = boneNames;
+            NormalizedBoneNameToIndex = normalizedBoneIndex;
+            BonePalette = bonePalette;
+            Descriptor = descriptor;
+            VertexCount = vertexCount;
+            VertexStride = vertexStride;
+            VertexBufferOffset = vertexBufferOffset;
+            VertexBufferSize = vertexBufferSize;
+        }
+
+        public byte[] FileBytes { get; }
+
+        public IReadOnlyList<string> BoneNames { get; }
+
+        public IReadOnlyDictionary<string, int> NormalizedBoneNameToIndex { get; }
+
+        public IReadOnlyList<ushort> BonePalette { get; }
+
+        public PsgVertexDescriptor Descriptor { get; }
+
+        public int VertexCount { get; }
+
+        public int VertexStride { get; }
+
+        public int VertexBufferOffset { get; }
+
+        public int VertexBufferSize { get; }
+
+        public static PsgDonorMesh Load(ReadOnlySpan<byte> data, Action<string>? log = null)
+        {
+            log ??= _ => { };
+            if (data.Length < 0x60)
+            {
+                throw new InvalidOperationException("File is too small to be a valid PSG arena.");
+            }
+
+            var bytes = data.ToArray();
+            var arena = ParseArena(bytes);
+            log($"[Arena] entries={arena.Dict.Count} types={arena.Types.Count}");
+
+            var carrier = FindCarrier(bytes, arena) ?? throw new InvalidOperationException("Could not locate skeleton carrier in donor PSG.");
+            log($"[Carrier] dict#{carrier.Index} range=0x{carrier.BlockStart:X}-0x{carrier.BlockEnd:X}");
+
+            var boneNames = ReadBoneNames(bytes, carrier, out var boneMap);
+            log($"[Bones] count={boneNames.Count}");
+
+            var paletteEntry = arena.Dict.FirstOrDefault(e => e.TypeId == 0x00EB0023)
+                ?? throw new InvalidOperationException("Bone palette entry (type 0x00EB0023) not found in donor PSG.");
+            var palette = ReadBonePalette(bytes, paletteEntry, boneNames.Count);
+            log($"[Palette] entries={palette.Count} dict#{paletteEntry.Index}");
+
+            var submeshes = ResolveSubMeshes(bytes, arena);
+            if (submeshes.Count == 0)
+            {
+                throw new InvalidOperationException("No vertex descriptors/vertex buffers could be paired in donor PSG.");
+            }
+
+            var baseSub = ChooseBaseSubMesh(submeshes);
+            log($"[SubMesh] chosen VDES#{baseSub.Vdes.Index} VB#{baseSub.Vb.Index} stride={baseSub.Descriptor.Stride} verts={baseSub.VertexCount}");
+
+            if (baseSub.Descriptor.IndicesElement == null || baseSub.Descriptor.WeightsElement == null)
+            {
+                throw new InvalidOperationException("Base submesh does not expose indices and weights in the active stream.");
+            }
+
+            return new PsgDonorMesh(
+                bytes,
+                boneNames,
+                boneMap,
+                palette,
+                baseSub.Descriptor,
+                baseSub.VertexCount,
+                baseSub.Descriptor.Stride,
+                baseSub.VertexBufferStart,
+                baseSub.VertexBufferSize);
+        }
+
+        public static string NormalizeBoneName(string? name)
+        {
+            return PsgNameUtilities.Normalize(name);
+        }
+
+        public int GetPaletteSlotForGlobalBone(int globalIndex)
+        {
+            for (int i = 0; i < BonePalette.Count; i++)
+            {
+                if (BonePalette[i] == globalIndex)
+                {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        private static IReadOnlyList<string> ReadBoneNames(byte[] data, DictEntry carrier, out Dictionary<string, int> normalizedMap)
+        {
+            int header = carrier.BlockStart + 0x20;
+            uint offIdx = BE.U32(data, header + 0x08);
+            uint offNames = BE.U32(data, header + 0x0C);
+            ushort boneCount = BE.U16(data, header + 0x14);
+
+            int idxBase = carrier.BlockStart + (int)offIdx;
+            int nameBase = carrier.BlockStart + (int)offNames;
+
+            var names = new List<string>(boneCount);
+            normalizedMap = new Dictionary<string, int>(boneCount);
+
+            for (int i = 0; i < boneCount; i++)
+            {
+                uint rel = BE.U32(data, idxBase + i * 4);
+                int strPos = carrier.BlockStart + (int)rel;
+                string name = ReadCString(data, strPos, carrier.BlockEnd);
+                names.Add(name);
+
+                string key = PsgNameUtilities.Normalize(name);
+                if (!normalizedMap.ContainsKey(key))
+                {
+                    normalizedMap[key] = i;
+                }
+            }
+
+            return names;
+        }
+
+        private static IReadOnlyList<ushort> ReadBonePalette(byte[] data, DictEntry paletteEntry, int boneCount)
+        {
+            var palette = new List<ushort>();
+            int pos = paletteEntry.BlockStart + 0x6C;
+            while (pos + 1 < paletteEntry.BlockEnd)
+            {
+                ushort value = BE.U16(data, pos);
+                if (value == 0xFFFF || value >= boneCount)
+                {
+                    break;
+                }
+                palette.Add(value);
+                pos += 2;
+            }
+            if (palette.Count == 0)
+            {
+                throw new InvalidOperationException("Bone palette is empty in donor PSG.");
+            }
+            return palette;
+        }
+
+        private static List<ResolvedSubMesh> ResolveSubMeshes(byte[] data, Arena arena)
+        {
+            var vdesList = arena.Dict.Where(x => x.TypeId == 0x000200E9).OrderBy(x => x.Index).ToList();
+            var vbList = arena.Dict.Where(x => x.TypeId == 0x000200EA).OrderBy(x => x.Index).ToList();
+            var ibList = arena.Dict.Where(x => x.TypeId == 0x000200EB).OrderBy(x => x.Index).ToList();
+
+            var descriptors = new List<(DictEntry Vdes, PsgVertexDescriptor Descriptor)>();
+            foreach (var vdes in vdesList)
+            {
+                var vd = ParseVertexDescriptor(data, vdes);
+                ChooseActiveStream(vd);
+                descriptors.Add((vdes, new PsgVertexDescriptor(vd)));
+            }
+
+            var resolved = new List<ResolvedSubMesh>();
+            var usedVbs = new HashSet<int>();
+
+            for (int i = 0; i < descriptors.Count; i++)
+            {
+                var (vdesEntry, descriptor) = descriptors[i];
+
+                DictEntry? chosenVb = null;
+                int vertexCount = 0;
+
+                foreach (var vb in vbList)
+                {
+                    if (usedVbs.Contains(vb.Index)) continue;
+
+                    if (vb.BlockStart + 12 > data.Length) continue;
+                    uint brIndex = BE.U32(data, vb.BlockStart + 0);
+                    var br = arena.Dict.ElementAtOrDefault((int)brIndex);
+                    if (br == null || !arena.IsBaseResource(br.TypeId)) continue;
+
+                    int size = (int)br.Size;
+                    int stride = descriptor.Stride > 0 ? descriptor.Stride : descriptor.Elements.FirstOrDefault()?.Stride ?? 0;
+                    if (stride <= 0 || size <= 0) continue;
+                    if (size % stride != 0) continue;
+
+                    chosenVb = vb;
+                    vertexCount = size / stride;
+                    break;
+                }
+
+                if (chosenVb == null) continue;
+                usedVbs.Add(chosenVb.Index);
+
+                DictEntry? nextVdes = (i + 1 < descriptors.Count) ? descriptors[i + 1].Vdes : null;
+                DictEntry? chosenIb = ibList.FirstOrDefault(ib => ib.Index > vdesEntry.Index && (nextVdes == null || ib.Index < nextVdes.Index));
+
+                uint vbBrIndex = BE.U32(data, chosenVb.BlockStart + 0);
+                var vbBr = arena.Dict.ElementAtOrDefault((int)vbBrIndex);
+                if (vbBr == null || !arena.IsBaseResource(vbBr.TypeId)) continue;
+
+                resolved.Add(new ResolvedSubMesh
+                {
+                    Vdes = vdesEntry,
+                    Vb = chosenVb,
+                    Ib = chosenIb,
+                    Descriptor = descriptor,
+                    VertexCount = vertexCount,
+                    VertexBufferStart = vbBr.BlockStart,
+                    VertexBufferSize = (int)vbBr.Size
+                });
+            }
+
+            return resolved;
+        }
+
+        private static ResolvedSubMesh ChooseBaseSubMesh(List<ResolvedSubMesh> submeshes)
+        {
+            var candidates = submeshes
+                .Where(s => s.Ib != null && s.Descriptor.IndicesElement != null && s.Descriptor.WeightsElement != null)
+                .ToList();
+
+            if (candidates.Count == 0)
+            {
+                candidates = submeshes
+                    .Where(s => s.Descriptor.IndicesElement != null && s.Descriptor.WeightsElement != null)
+                    .ToList();
+            }
+
+            if (candidates.Count == 0)
+            {
+                throw new InvalidOperationException("Unable to identify a base submesh containing indices and weights.");
+            }
+
+            return candidates
+                .OrderByDescending(s => s.Descriptor.HasTangent ? 1 : 0)
+                .ThenByDescending(s => s.Descriptor.HasBinormal ? 1 : 0)
+                .ThenByDescending(s => s.Descriptor.HasTexCoord)
+                .ThenByDescending(s => s.Descriptor.Stride)
+                .First();
+        }
+
+        private static VertexDescriptorInfo ParseVertexDescriptor(byte[] data, DictEntry entry)
+        {
+            if (entry.BlockStart + 16 > data.Length)
+            {
+                throw new InvalidOperationException("Vertex descriptor header is out of range.");
+            }
+
+            ushort elementCount = BE.U16(data, entry.BlockStart + 10);
+            var elements = new List<VertexElementInfo>(elementCount);
+            int offset = entry.BlockStart + 16;
+
+            for (int i = 0; i < elementCount && offset + 8 <= entry.BlockEnd; i++, offset += 8)
+            {
+                elements.Add(new VertexElementInfo
+                {
+                    VertexType = data[offset + 0],
+                    ComponentCount = data[offset + 1],
+                    Stream = data[offset + 2],
+                    Offset = data[offset + 3],
+                    Stride = BE.U16(data, offset + 4),
+                    ElementType = data[offset + 6],
+                    Class = data[offset + 7]
+                });
+            }
+
+            return new VertexDescriptorInfo(elements);
+        }
+
+        private static void ChooseActiveStream(VertexDescriptorInfo descriptor)
+        {
+            var groups = descriptor.Elements.GroupBy(e => e.Stream).ToList();
+
+            (bool hasIdx, bool hasWgt, bool hasXyz, bool hasNrm, bool hasTan, bool hasBin, bool hasTex, int stride, VertexElementInfo? idx, VertexElementInfo? wgt) Analyze(IEnumerable<VertexElementInfo> elems)
+            {
+                bool idx = false, wgt = false, xyz = false, nrm = false, tan = false, bin = false, tex = false;
+                int strideMax = 0;
+                VertexElementInfo? idxEl = null, wgtEl = null;
+
+                foreach (var e in elems)
+                {
+                    strideMax = Math.Max(strideMax, e.Stride);
+                    switch ((PsgVertexElementType)e.ElementType)
+                    {
+                        case PsgVertexElementType.Indices:
+                            idx = true; idxEl = e; break;
+                        case PsgVertexElementType.Weights:
+                            wgt = true; wgtEl = e; break;
+                        case PsgVertexElementType.Xyz:
+                            xyz = true; break;
+                        case PsgVertexElementType.Normal:
+                            nrm = true; break;
+                        case PsgVertexElementType.Tangent:
+                            tan = true; break;
+                        case PsgVertexElementType.Binormal:
+                            bin = true; break;
+                        case PsgVertexElementType.Tex0:
+                        case PsgVertexElementType.Tex1:
+                        case PsgVertexElementType.Tex2:
+                        case PsgVertexElementType.Tex3:
+                        case PsgVertexElementType.Tex4:
+                        case PsgVertexElementType.Tex5:
+                            tex = true; break;
+                    }
+                }
+
+                return (idx, wgt, xyz, nrm, tan, bin, tex, strideMax, idxEl, wgtEl);
+            }
+
+            var primary = groups
+                .Select(g => (g.Key, info: Analyze(g)))
+                .Where(x => x.info.hasIdx && x.info.hasWgt)
+                .OrderByDescending(x => x.info.stride)
+                .FirstOrDefault();
+
+            if (primary.info.stride > 0)
+            {
+                descriptor.ActiveStream = primary.Key;
+                descriptor.Stride = primary.info.stride;
+                descriptor.IndicesElement = primary.info.idx;
+                descriptor.WeightsElement = primary.info.wgt;
+                descriptor.HasXyz = primary.info.hasXyz;
+                descriptor.HasNormal = primary.info.hasNrm;
+                descriptor.HasTangent = primary.info.hasTan;
+                descriptor.HasBinormal = primary.info.hasBin;
+                descriptor.HasTex = primary.info.hasTex;
+                return;
+            }
+
+            var fallback = groups
+                .Select(g => (g.Key, info: Analyze(g)))
+                .OrderByDescending(x => x.info.stride)
+                .First();
+
+            descriptor.ActiveStream = fallback.Key;
+            descriptor.Stride = fallback.info.stride;
+            descriptor.IndicesElement = fallback.info.idx;
+            descriptor.WeightsElement = fallback.info.wgt;
+            descriptor.HasXyz = fallback.info.hasXyz;
+            descriptor.HasNormal = fallback.info.hasNrm;
+            descriptor.HasTangent = fallback.info.hasTan;
+            descriptor.HasBinormal = fallback.info.hasBin;
+            descriptor.HasTex = fallback.info.hasTex;
+        }
+
+        private static Arena ParseArena(byte[] data)
+        {
+            uint numEntries = BE.U32(data, 0x20);
+            uint dictStart = BE.U32(data, 0x30);
+            uint mainBase = BE.U32(data, 0x44);
+            uint sections = BE.U32(data, 0x34);
+
+            var arena = new Arena { DictStart = dictStart, ResourceMainBase = mainBase };
+
+            if (sections != 0)
+            {
+                const uint SectionTypesId = 0x00010005;
+                for (int p = (int)sections; p <= data.Length - 12; p += 4)
+                {
+                    if (BE.U32(data, p) != SectionTypesId) continue;
+                    uint count = BE.U32(data, p + 4);
+                    uint dictOffset = BE.U32(data, p + 8);
+                    int baseOffset = p + (int)dictOffset;
+                    for (int i = 0; i < count && baseOffset + i * 4 <= data.Length - 4; i++)
+                    {
+                        arena.Types.Add(BE.U32(data, baseOffset + i * 4));
+                    }
+                    break;
+                }
+            }
+
+            for (int i = 0, q = (int)dictStart; i < numEntries && q + 0x18 <= data.Length; i++, q += 0x18)
+            {
+                uint ptr = BE.U32(data, q + 0x00);
+                uint size = BE.U32(data, q + 0x08);
+                uint align = BE.U32(data, q + 0x0C);
+                uint typeIndex = BE.U32(data, q + 0x10);
+                uint typeId = BE.U32(data, q + 0x14);
+
+                if (arena.Types.Count > 0 && typeIndex < arena.Types.Count)
+                {
+                    typeId = arena.Types[(int)typeIndex];
+                }
+
+                int blockStart = arena.IsBaseResource(typeId) ? (int)(mainBase + ptr) : (int)ptr;
+                int blockEnd = Math.Min(data.Length, Math.Max(blockStart, blockStart + (int)size));
+
+                arena.Dict.Add(new DictEntry
+                {
+                    Index = i,
+                    Ptr = ptr,
+                    Size = size,
+                    Align = align,
+                    TypeIndex = typeIndex,
+                    TypeId = typeId,
+                    BlockStart = blockStart,
+                    BlockEnd = blockEnd
+                });
+            }
+
+            return arena;
+        }
+
+        private static DictEntry? FindCarrier(byte[] data, Arena arena)
+        {
+            foreach (var entry in arena.Dict)
+            {
+                int header = entry.BlockStart + 0x20;
+                if (header + 0x24 > data.Length) continue;
+
+                uint offIbm = BE.U32(data, header + 0x00);
+                uint offIndex = BE.U32(data, header + 0x08);
+                uint offNames = BE.U32(data, header + 0x0C);
+                ushort boneCount = BE.U16(data, header + 0x14);
+
+                if (boneCount == 0 || boneCount > 512) continue;
+
+                int ibmAbs = entry.BlockStart + (int)offIbm;
+                int idxAbs = entry.BlockStart + (int)offIndex;
+                int nameAbs = entry.BlockStart + (int)offNames;
+
+                if (!entry.Contains(ibmAbs, boneCount * 64)) continue;
+                if (!entry.Contains(idxAbs, boneCount * 4)) continue;
+                if (!entry.Contains(nameAbs, 1)) continue;
+
+                int rel0 = (int)BE.U32(data, idxAbs);
+                int str0 = entry.BlockStart + rel0;
+                if (!entry.Contains(str0, 1)) continue;
+                if (!LooksLikeCString(data, str0, entry.BlockEnd)) continue;
+
+                return entry;
+            }
+
+            return null;
+        }
+
+        private static string ReadCString(byte[] data, int start, int limit)
+        {
+            if (start < 0 || start >= data.Length) return string.Empty;
+            var sb = new StringBuilder();
+            int max = Math.Min(limit, data.Length);
+            for (int i = start; i < max; i++)
+            {
+                byte b = data[i];
+                if (b == 0) break;
+                sb.Append((char)b);
+            }
+            return sb.ToString();
+        }
+
+        private static bool LooksLikeCString(byte[] data, int offset, int limit)
+        {
+            int max = Math.Min(limit, offset + 64);
+            for (int i = offset; i < max; i++)
+            {
+                byte b = data[i];
+                if (b == 0) return true;
+                if (b < 0x20 || b > 0x7E) return false;
+            }
+            return false;
+        }
+
+        private sealed class Arena
+        {
+            public uint DictStart { get; set; }
+            public uint ResourceMainBase { get; set; }
+            public List<uint> Types { get; } = new();
+            public List<DictEntry> Dict { get; } = new();
+            public bool IsBaseResource(uint typeId) => typeId >= 0x00010030 && typeId <= 0x0001003F;
+        }
+
+        private sealed class DictEntry
+        {
+            public int Index { get; set; }
+            public uint Ptr { get; set; }
+            public uint Size { get; set; }
+            public uint Align { get; set; }
+            public uint TypeIndex { get; set; }
+            public uint TypeId { get; set; }
+            public int BlockStart { get; set; }
+            public int BlockEnd { get; set; }
+
+            public bool Contains(int start, int length) => start >= BlockStart && start + length <= BlockEnd;
+        }
+
+        private sealed class ResolvedSubMesh
+        {
+            public DictEntry Vdes { get; set; } = default!;
+            public DictEntry Vb { get; set; } = default!;
+            public DictEntry? Ib { get; set; }
+            public PsgVertexDescriptor Descriptor { get; set; } = default!;
+            public int VertexCount { get; set; }
+            public int VertexBufferStart { get; set; }
+            public int VertexBufferSize { get; set; }
+        }
+
+        private static class BE
+        {
+            public static ushort U16(byte[] d, int o) => (ushort)((d[o] << 8) | d[o + 1]);
+            public static uint U32(byte[] d, int o) => ((uint)d[o] << 24) | ((uint)d[o + 1] << 16) | ((uint)d[o + 2] << 8) | d[o + 3];
+        }
+    }
+
+    public enum PsgVertexComponentType : byte
+    {
+        S1 = 0x01,
+        Float32 = 0x02,
+        Float16 = 0x03,
+        UByteNormalized = 0x04,
+        S32K = 0x05,
+        PackedCmp = 0x06,
+        UByte = 0x07
+    }
+
+    public enum PsgVertexElementType : byte
+    {
+        Xyz = 0x00,
+        Weights = 0x01,
+        Normal = 0x02,
+        VertexColor = 0x03,
+        Specular = 0x04,
+        Indices = 0x07,
+        Tex0 = 0x08,
+        Tex1 = 0x09,
+        Tex2 = 0x0A,
+        Tex3 = 0x0B,
+        Tex4 = 0x0C,
+        Tex5 = 0x0D,
+        Tangent = 0x0E,
+        Binormal = 0x0F
+    }
+
+    internal sealed class VertexElementInfo
+    {
+        public byte VertexType { get; set; }
+        public byte ComponentCount { get; set; }
+        public byte Stream { get; set; }
+        public byte Offset { get; set; }
+        public ushort Stride { get; set; }
+        public byte ElementType { get; set; }
+        public byte Class { get; set; }
+    }
+
+    internal sealed class VertexDescriptorInfo
+    {
+        public VertexDescriptorInfo(List<VertexElementInfo> elements)
+        {
+            Elements = elements;
+        }
+
+        public List<VertexElementInfo> Elements { get; }
+        public int ActiveStream { get; set; }
+        public int Stride { get; set; }
+        public VertexElementInfo? IndicesElement { get; set; }
+        public VertexElementInfo? WeightsElement { get; set; }
+        public bool HasXyz { get; set; }
+        public bool HasNormal { get; set; }
+        public bool HasTangent { get; set; }
+        public bool HasBinormal { get; set; }
+        public bool HasTex { get; set; }
+    }
+
+    public sealed class PsgVertexDescriptor
+    {
+        private readonly List<PsgVertexElement> _elements;
+
+        internal PsgVertexDescriptor(VertexDescriptorInfo info)
+        {
+            _elements = info.Elements.Select(e => new PsgVertexElement(
+                (PsgVertexComponentType)e.VertexType,
+                e.ComponentCount,
+                e.Stream,
+                e.Offset,
+                e.Stride,
+                (PsgVertexElementType)e.ElementType,
+                e.Class)).ToList();
+
+            ActiveStream = info.ActiveStream;
+            Stride = info.Stride;
+            IndicesElement = info.IndicesElement != null ? _elements.FirstOrDefault(e => e.Offset == info.IndicesElement.Offset && e.Stream == info.IndicesElement.Stream) : null;
+            WeightsElement = info.WeightsElement != null ? _elements.FirstOrDefault(e => e.Offset == info.WeightsElement.Offset && e.Stream == info.WeightsElement.Stream) : null;
+            HasNormal = info.HasNormal;
+            HasTangent = info.HasTangent;
+            HasBinormal = info.HasBinormal;
+            HasTexCoord = info.HasTex;
+        }
+
+        public IReadOnlyList<PsgVertexElement> Elements => _elements;
+
+        public int ActiveStream { get; }
+
+        public int Stride { get; }
+
+        public bool HasNormal { get; }
+
+        public bool HasTangent { get; }
+
+        public bool HasBinormal { get; }
+
+        public bool HasTexCoord { get; }
+
+        public PsgVertexElement? IndicesElement { get; }
+
+        public PsgVertexElement? WeightsElement { get; }
+
+        public PsgVertexElement? FindElement(PsgVertexElementType type)
+        {
+            return _elements.FirstOrDefault(e => e.ElementType == type && e.Stream == ActiveStream);
+        }
+    }
+
+    public sealed class PsgVertexElement
+    {
+        internal PsgVertexElement(PsgVertexComponentType vertexType, byte componentCount, byte stream, byte offset, ushort stride, PsgVertexElementType elementType, byte elementClass)
+        {
+            ComponentType = vertexType;
+            ComponentCount = componentCount;
+            Stream = stream;
+            Offset = offset;
+            Stride = stride;
+            ElementType = elementType;
+            ElementClass = elementClass;
+        }
+
+        public PsgVertexComponentType ComponentType { get; }
+        public byte ComponentCount { get; }
+        public byte Stream { get; }
+        public byte Offset { get; }
+        public ushort Stride { get; }
+        public PsgVertexElementType ElementType { get; }
+        public byte ElementClass { get; }
+    }
+
+    internal static class PsgNameUtilities
+    {
+        public static string Normalize(string? name)
+        {
+            if (string.IsNullOrWhiteSpace(name)) return string.Empty;
+            var sb = new StringBuilder(name.Length);
+            foreach (char c in name)
+            {
+                if (char.IsWhiteSpace(c) || c == '_' || c == '-' )
+                {
+                    continue;
+                }
+                sb.Append(char.ToUpperInvariant(c));
+            }
+            return sb.ToString();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable PSG donor mesh parser that exposes bone names, palette, and vertex descriptor details
- create a WinForms GLTF to PSG converter that reuses donor armature data and rewrites vertex buffers while undoing Blender import transforms
- update the solution to include the new converter project and SharpGLTF dependency

## Testing
- `dotnet --version` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d08de70120832c8201679e9bd0d612